### PR TITLE
hotfix/2: указана конкретная версия mongo образа

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 #DATABASE
 services:
   mongo_db:
-    image: mongo:latest
+    image: mongo:4.4.6
     container_name: 'mongo_db'
     restart: always
     ports:


### PR DESCRIPTION
- указана конкретная версия mongo образа в связи с тем, что последние версии mongo не работают с процессорами без поддержки AVX